### PR TITLE
Make logging customizable

### DIFF
--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/DebugSession.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/DebugSession.java
@@ -13,6 +13,7 @@ package com.microsoft.java.debug.core;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.logging.Logger;
 
 import com.sun.jdi.ThreadReference;
 import com.sun.jdi.VirtualMachine;
@@ -22,10 +23,11 @@ import com.sun.jdi.request.ExceptionRequest;
 
 public class DebugSession implements IDebugSession {
     private VirtualMachine vm;
-    private EventHub eventHub = new EventHub();
+    private EventHub eventHub;
 
-    public DebugSession(VirtualMachine virtualMachine) {
+    public DebugSession(VirtualMachine virtualMachine, Logger logger) {
         vm = virtualMachine;
+        eventHub = new EventHub(logger);
     }
 
     @Override

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/DebugSettings.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/DebugSettings.java
@@ -18,7 +18,7 @@ import com.google.gson.annotations.SerializedName;
 import com.microsoft.java.debug.core.protocol.JsonUtils;
 
 public final class DebugSettings {
-    private static final Logger logger = Logger.getLogger(Configuration.LOGGER_NAME);
+    private final Logger logger = Logger.getLogger(Configuration.LOGGER_NAME);
     private static DebugSettings current = new DebugSettings();
 
     public int maxStringLength = 0;

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/DebugSettings.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/DebugSettings.java
@@ -11,14 +11,11 @@
 
 package com.microsoft.java.debug.core;
 
-import java.util.logging.Logger;
-
 import com.google.gson.JsonSyntaxException;
 import com.google.gson.annotations.SerializedName;
 import com.microsoft.java.debug.core.protocol.JsonUtils;
 
 public final class DebugSettings {
-    private final Logger logger = Logger.getLogger(Configuration.LOGGER_NAME);
     private static DebugSettings current = new DebugSettings();
 
     public int maxStringLength = 0;
@@ -41,12 +38,8 @@ public final class DebugSettings {
      * @param jsonSettings
      *            the new settings represents in json format.
      */
-    public void updateSettings(String jsonSettings) {
-        try {
-            current = JsonUtils.fromJson(jsonSettings, DebugSettings.class);
-        } catch (JsonSyntaxException ex) {
-            logger.severe(String.format("Invalid json for debugSettings: %s, %s", jsonSettings, ex.getMessage()));
-        }
+    public void updateSettings(String jsonSettings) throws JsonSyntaxException {
+        current = JsonUtils.fromJson(jsonSettings, DebugSettings.class);
     }
 
     private DebugSettings() {

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/EventHub.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/EventHub.java
@@ -31,8 +31,12 @@ import io.reactivex.Observable;
 import io.reactivex.subjects.PublishSubject;
 
 public class EventHub implements IEventHub {
-    private final Logger logger = Logger.getLogger(Configuration.LOGGER_NAME);
+    private final Logger logger;
     private PublishSubject<DebugEvent> subject = PublishSubject.<DebugEvent>create();
+
+    public EventHub(Logger logger) {
+        this.logger = logger;
+    }
 
     @Override
     public Observable<DebugEvent> events() {

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/EventHub.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/EventHub.java
@@ -31,7 +31,7 @@ import io.reactivex.Observable;
 import io.reactivex.subjects.PublishSubject;
 
 public class EventHub implements IEventHub {
-    private static final Logger logger = Logger.getLogger(Configuration.LOGGER_NAME);
+    private final Logger logger = Logger.getLogger(Configuration.LOGGER_NAME);
     private PublishSubject<DebugEvent> subject = PublishSubject.<DebugEvent>create();
 
     @Override

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/LoggerFactory.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/LoggerFactory.java
@@ -1,0 +1,19 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Microsoft Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Microsoft Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.microsoft.java.debug.core;
+
+import java.util.logging.Logger;
+
+@FunctionalInterface
+public interface LoggerFactory {
+    Logger create(String name);
+}

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/UsageDataSession.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/UsageDataSession.java
@@ -16,7 +16,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
-import java.util.function.Function;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -56,9 +55,9 @@ public class UsageDataSession {
     /**
      * Constructor.
      */
-    public UsageDataSession(Logger logger, Function<String, Logger> loggerFactory) {
+    public UsageDataSession(Logger logger, LoggerFactory factory) {
         this.logger = logger;
-        this.usageDataLogger = loggerFactory.apply(Configuration.USAGE_DATA_LOGGER_NAME);
+        this.usageDataLogger = factory.create(Configuration.USAGE_DATA_LOGGER_NAME);
         threadLocal.set(this);
     }
 

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/UsageDataSession.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/UsageDataSession.java
@@ -1,13 +1,13 @@
 /*******************************************************************************
-* Copyright (c) 2017 Microsoft Corporation and others.
-* All rights reserved. This program and the accompanying materials
-* are made available under the terms of the Eclipse Public License v1.0
-* which accompanies this distribution, and is available at
-* http://www.eclipse.org/legal/epl-v10.html
-*
-* Contributors:
-*     Microsoft Corporation - initial API and implementation
-*******************************************************************************/
+ * Copyright (c) 2017 Microsoft Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Microsoft Corporation - initial API and implementation
+ *******************************************************************************/
 
 package com.microsoft.java.debug.core;
 
@@ -16,6 +16,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.function.Function;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -28,8 +29,8 @@ import com.microsoft.java.debug.core.protocol.Messages.Response;
 import com.sun.jdi.event.Event;
 
 public class UsageDataSession {
-    private final Logger logger = Logger.getLogger(Configuration.LOGGER_NAME);
-    private final Logger usageDataLogger = Logger.getLogger(Configuration.USAGE_DATA_LOGGER_NAME);
+    private final Logger logger;
+    private final Logger usageDataLogger;
     private static final long RESPONSE_MAX_DELAY_MS = 1000;
     private static final ThreadLocal<UsageDataSession> threadLocal = new InheritableThreadLocal<>();
 
@@ -52,7 +53,12 @@ public class UsageDataSession {
         return threadLocal.get();
     }
 
-    public UsageDataSession() {
+    /**
+     * Constructor.
+     */
+    public UsageDataSession(Logger logger, Function<String, Logger> loggerFactory) {
+        this.logger = logger;
+        this.usageDataLogger = loggerFactory.apply(Configuration.USAGE_DATA_LOGGER_NAME);
         threadLocal.set(this);
     }
 

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/BreakpointManager.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/BreakpointManager.java
@@ -20,11 +20,10 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import com.microsoft.java.debug.core.Configuration;
 import com.microsoft.java.debug.core.IBreakpoint;
 
 public class BreakpointManager {
-    private final Logger logger = Logger.getLogger(Configuration.LOGGER_NAME);
+    private final Logger logger;
     /**
      * A collection of breakpoints registered with this manager.
      */
@@ -35,7 +34,8 @@ public class BreakpointManager {
     /**
      * Constructor.
      */
-    public BreakpointManager() {
+    public BreakpointManager(Logger logger) {
+        this.logger = logger;
         this.breakpoints = Collections.synchronizedList(new ArrayList<>(5));
         this.sourceToBreakpoints = new HashMap<>();
     }

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/BreakpointManager.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/BreakpointManager.java
@@ -24,7 +24,7 @@ import com.microsoft.java.debug.core.Configuration;
 import com.microsoft.java.debug.core.IBreakpoint;
 
 public class BreakpointManager {
-    private static final Logger logger = Logger.getLogger(Configuration.LOGGER_NAME);
+    private final Logger logger = Logger.getLogger(Configuration.LOGGER_NAME);
     /**
      * A collection of breakpoints registered with this manager.
      */

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/DebugAdapter.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/DebugAdapter.java
@@ -47,7 +47,7 @@ import com.microsoft.java.debug.core.protocol.Requests.Arguments;
 import com.microsoft.java.debug.core.protocol.Requests.Command;
 
 public class DebugAdapter implements IDebugAdapter {
-    private static final Logger logger = Logger.getLogger(Configuration.LOGGER_NAME);
+    private final Logger logger = Logger.getLogger(Configuration.LOGGER_NAME);
 
     private IDebugAdapterContext debugContext = null;
     private Map<Command, List<IDebugRequestHandler>> requestHandlersForDebug = null;

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/DebugAdapter.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/DebugAdapter.java
@@ -19,7 +19,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import com.microsoft.java.debug.core.Configuration;
 import com.microsoft.java.debug.core.adapter.handler.AttachRequestHandler;
 import com.microsoft.java.debug.core.adapter.handler.CompletionsHandler;
 import com.microsoft.java.debug.core.adapter.handler.ConfigurationDoneRequestHandler;
@@ -47,7 +46,7 @@ import com.microsoft.java.debug.core.protocol.Requests.Arguments;
 import com.microsoft.java.debug.core.protocol.Requests.Command;
 
 public class DebugAdapter implements IDebugAdapter {
-    private final Logger logger = Logger.getLogger(Configuration.LOGGER_NAME);
+    private final Logger logger;
 
     private IDebugAdapterContext debugContext = null;
     private Map<Command, List<IDebugRequestHandler>> requestHandlersForDebug = null;
@@ -56,7 +55,8 @@ public class DebugAdapter implements IDebugAdapter {
     /**
      * Constructor.
      */
-    public DebugAdapter(IProtocolServer server, IProviderContext providerContext) {
+    public DebugAdapter(IProtocolServer server, IProviderContext providerContext, Logger logger) {
+        this.logger = logger;
         this.debugContext = new DebugAdapterContext(server, providerContext);
         requestHandlersForDebug = new HashMap<>();
         requestHandlersForNoDebug = new HashMap<>();
@@ -97,29 +97,29 @@ public class DebugAdapter implements IDebugAdapter {
         // Register request handlers.
         // When there are multiple handlers registered for the same request, follow the rule "first register, first execute".
         registerHandler(new InitializeRequestHandler());
-        registerHandler(new LaunchRequestHandler());
+        registerHandler(new LaunchRequestHandler(logger));
 
         // DEBUG node only
-        registerHandlerForDebug(new AttachRequestHandler());
-        registerHandlerForDebug(new ConfigurationDoneRequestHandler());
-        registerHandlerForDebug(new DisconnectRequestHandler());
-        registerHandlerForDebug(new SetBreakpointsRequestHandler());
+        registerHandlerForDebug(new AttachRequestHandler(logger));
+        registerHandlerForDebug(new ConfigurationDoneRequestHandler(logger));
+        registerHandlerForDebug(new DisconnectRequestHandler(logger));
+        registerHandlerForDebug(new SetBreakpointsRequestHandler(logger));
         registerHandlerForDebug(new SetExceptionBreakpointsRequestHandler());
         registerHandlerForDebug(new SourceRequestHandler());
         registerHandlerForDebug(new ThreadsRequestHandler());
         registerHandlerForDebug(new StepRequestHandler());
         registerHandlerForDebug(new StackTraceRequestHandler());
         registerHandlerForDebug(new ScopesRequestHandler());
-        registerHandlerForDebug(new VariablesRequestHandler());
+        registerHandlerForDebug(new VariablesRequestHandler(logger));
         registerHandlerForDebug(new SetVariableRequestHandler());
-        registerHandlerForDebug(new EvaluateRequestHandler());
+        registerHandlerForDebug(new EvaluateRequestHandler(logger));
         registerHandlerForDebug(new HotCodeReplaceHandler());
         registerHandlerForDebug(new RestartFrameHandler());
         registerHandlerForDebug(new CompletionsHandler());
-        registerHandlerForDebug(new ExceptionInfoRequestHandler());
+        registerHandlerForDebug(new ExceptionInfoRequestHandler(logger));
 
         // NO_DEBUG mode only
-        registerHandlerForNoDebug(new DisconnectRequestWithoutDebuggingHandler());
+        registerHandlerForNoDebug(new DisconnectRequestWithoutDebuggingHandler(logger));
 
     }
 

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/ProtocolServer.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/ProtocolServer.java
@@ -29,7 +29,7 @@ import com.microsoft.java.debug.core.protocol.Messages;
 import com.sun.jdi.VMDisconnectedException;
 
 public class ProtocolServer extends AbstractProtocolServer {
-    private static final Logger logger = Logger.getLogger(Configuration.LOGGER_NAME);
+    private final Logger logger = Logger.getLogger(Configuration.LOGGER_NAME);
 
     private IDebugAdapter debugAdapter;
     private UsageDataSession usageDataSession = new UsageDataSession();

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/ProtocolServer.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/ProtocolServer.java
@@ -16,12 +16,12 @@ import java.io.OutputStream;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentLinkedQueue;
-import java.util.function.Function;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import com.microsoft.java.debug.core.Configuration;
 import com.microsoft.java.debug.core.DebugException;
+import com.microsoft.java.debug.core.LoggerFactory;
 import com.microsoft.java.debug.core.UsageDataSession;
 import com.microsoft.java.debug.core.protocol.AbstractProtocolServer;
 import com.microsoft.java.debug.core.protocol.Events.DebugEvent;
@@ -41,10 +41,10 @@ public class ProtocolServer extends AbstractProtocolServer {
     /**
      * Constructor.
      */
-    public ProtocolServer(InputStream input, OutputStream output, IProviderContext context, Function<String, Logger> loggerFactory) {
-        super(input, output, loggerFactory.apply(Configuration.LOGGER_NAME));
+    public ProtocolServer(InputStream input, OutputStream output, IProviderContext context, LoggerFactory factory) {
+        super(input, output, factory.create(Configuration.LOGGER_NAME));
         debugAdapter = new DebugAdapter(this, context, logger);
-        usageDataSession = new UsageDataSession(logger, loggerFactory);
+        usageDataSession = new UsageDataSession(logger, factory);
     }
 
     /**

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/AbstractDisconnectRequestHandler.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/AbstractDisconnectRequestHandler.java
@@ -20,7 +20,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import com.microsoft.java.debug.core.Configuration;
 import com.microsoft.java.debug.core.adapter.IDebugAdapterContext;
 import com.microsoft.java.debug.core.adapter.IDebugRequestHandler;
 import com.microsoft.java.debug.core.adapter.LaunchMode;
@@ -29,7 +28,11 @@ import com.microsoft.java.debug.core.protocol.Requests.Arguments;
 import com.microsoft.java.debug.core.protocol.Requests.Command;
 
 public abstract class AbstractDisconnectRequestHandler implements IDebugRequestHandler {
-    private final Logger logger = Logger.getLogger(Configuration.LOGGER_NAME);
+    private final Logger logger;
+
+    public AbstractDisconnectRequestHandler(Logger logger) {
+        this.logger = logger;
+    }
 
     @Override
     public List<Command> getTargetCommands() {

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/AbstractDisconnectRequestHandler.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/AbstractDisconnectRequestHandler.java
@@ -29,7 +29,7 @@ import com.microsoft.java.debug.core.protocol.Requests.Arguments;
 import com.microsoft.java.debug.core.protocol.Requests.Command;
 
 public abstract class AbstractDisconnectRequestHandler implements IDebugRequestHandler {
-    private static final Logger logger = Logger.getLogger(Configuration.LOGGER_NAME);
+    private final Logger logger = Logger.getLogger(Configuration.LOGGER_NAME);
 
     @Override
     public List<Command> getTargetCommands() {

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/AbstractLaunchDelegate.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/AbstractLaunchDelegate.java
@@ -1,0 +1,51 @@
+/*******************************************************************************
+* Copyright (c) 2017 Microsoft Corporation and others.
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Eclipse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Microsoft Corporation - initial API and implementation
+*******************************************************************************/
+
+package com.microsoft.java.debug.core.adapter.handler;
+
+import com.microsoft.java.debug.core.Configuration;
+import com.microsoft.java.debug.core.protocol.Requests;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Logger;
+
+abstract class AbstractLaunchDelegate implements ILaunchDelegate {
+    protected final Logger logger = Logger.getLogger(Configuration.LOGGER_NAME);
+
+    protected String[] constructEnvironmentVariables(Requests.LaunchArguments launchArguments) {
+        String[] envVars = null;
+        if (launchArguments.env != null && !launchArguments.env.isEmpty()) {
+            Map<String, String> environment = new HashMap<>(System.getenv());
+            List<String> duplicated = new ArrayList<>();
+            for (Map.Entry<String, String> entry : launchArguments.env.entrySet()) {
+                if (environment.containsKey(entry.getKey())) {
+                    duplicated.add(entry.getKey());
+                }
+                environment.put(entry.getKey(), entry.getValue());
+            }
+            // For duplicated variables, show a warning message.
+            if (!duplicated.isEmpty()) {
+                logger.warning(String.format("There are duplicated environment variables. The values specified in launch.json will be used. "
+                        + "Here are the duplicated entries: %s.", String.join(",", duplicated)));
+            }
+
+            envVars = new String[environment.size()];
+            int i = 0;
+            for (Map.Entry<String, String> entry : environment.entrySet()) {
+                envVars[i++] = entry.getKey() + "=" + entry.getValue();
+            }
+        }
+        return envVars;
+    }
+}

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/AbstractLaunchDelegate.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/AbstractLaunchDelegate.java
@@ -11,17 +11,20 @@
 
 package com.microsoft.java.debug.core.adapter.handler;
 
-import com.microsoft.java.debug.core.Configuration;
-import com.microsoft.java.debug.core.protocol.Requests;
-
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.logging.Logger;
 
+import com.microsoft.java.debug.core.protocol.Requests;
+
 abstract class AbstractLaunchDelegate implements ILaunchDelegate {
-    protected final Logger logger = Logger.getLogger(Configuration.LOGGER_NAME);
+    protected final Logger logger;
+
+    protected AbstractLaunchDelegate(Logger logger) {
+        this.logger = logger;
+    }
 
     protected String[] constructEnvironmentVariables(Requests.LaunchArguments launchArguments) {
         String[] envVars = null;

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/AttachRequestHandler.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/AttachRequestHandler.java
@@ -41,7 +41,7 @@ import com.microsoft.java.debug.core.protocol.Requests.Command;
 import com.sun.jdi.connect.IllegalConnectorArgumentsException;
 
 public class AttachRequestHandler implements IDebugRequestHandler {
-    private static final Logger logger = Logger.getLogger(Configuration.LOGGER_NAME);
+    private final Logger logger = Logger.getLogger(Configuration.LOGGER_NAME);
 
     @Override
     public List<Command> getTargetCommands() {

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/AttachRequestHandler.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/AttachRequestHandler.java
@@ -20,7 +20,6 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.logging.Logger;
 
-import com.microsoft.java.debug.core.Configuration;
 import com.microsoft.java.debug.core.DebugUtility;
 import com.microsoft.java.debug.core.IDebugSession;
 import com.microsoft.java.debug.core.adapter.AdapterUtils;
@@ -41,7 +40,11 @@ import com.microsoft.java.debug.core.protocol.Requests.Command;
 import com.sun.jdi.connect.IllegalConnectorArgumentsException;
 
 public class AttachRequestHandler implements IDebugRequestHandler {
-    private final Logger logger = Logger.getLogger(Configuration.LOGGER_NAME);
+    private final Logger logger;
+
+    public AttachRequestHandler(Logger logger) {
+        this.logger = logger;
+    }
 
     @Override
     public List<Command> getTargetCommands() {
@@ -61,7 +64,7 @@ public class AttachRequestHandler implements IDebugRequestHandler {
         try {
             logger.info(String.format("Trying to attach to remote debuggee VM %s:%d .", attachArguments.hostName, attachArguments.port));
             IDebugSession debugSession = DebugUtility.attach(vmProvider.getVirtualMachineManager(), attachArguments.hostName, attachArguments.port,
-                    attachArguments.timeout);
+                    attachArguments.timeout, logger);
             context.setDebugSession(debugSession);
             logger.info("Attaching to debuggee VM succeeded.");
 

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/ConfigurationDoneRequestHandler.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/ConfigurationDoneRequestHandler.java
@@ -16,7 +16,6 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.logging.Logger;
 
-import com.microsoft.java.debug.core.Configuration;
 import com.microsoft.java.debug.core.DebugEvent;
 import com.microsoft.java.debug.core.DebugUtility;
 import com.microsoft.java.debug.core.IDebugSession;
@@ -42,7 +41,11 @@ import com.sun.jdi.event.VMDisconnectEvent;
 import com.sun.jdi.event.VMStartEvent;
 
 public class ConfigurationDoneRequestHandler implements IDebugRequestHandler {
-    protected final Logger logger = Logger.getLogger(Configuration.LOGGER_NAME);
+    protected final Logger logger;
+
+    public ConfigurationDoneRequestHandler(Logger logger) {
+        this.logger = logger;
+    }
 
     @Override
     public List<Command> getTargetCommands() {

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/ConfigurationDoneRequestHandler.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/ConfigurationDoneRequestHandler.java
@@ -42,7 +42,7 @@ import com.sun.jdi.event.VMDisconnectEvent;
 import com.sun.jdi.event.VMStartEvent;
 
 public class ConfigurationDoneRequestHandler implements IDebugRequestHandler {
-    protected static final Logger logger = Logger.getLogger(Configuration.LOGGER_NAME);
+    protected final Logger logger = Logger.getLogger(Configuration.LOGGER_NAME);
 
     @Override
     public List<Command> getTargetCommands() {
@@ -120,7 +120,10 @@ public class ConfigurationDoneRequestHandler implements IDebugRequestHandler {
 
         // record events of important types only, to get rid of noises.
         if (isImportantEvent) {
-            UsageDataSession.recordEvent(event);
+            UsageDataSession session = UsageDataSession.currentSession();
+            if (session != null) {
+                session.recordEvent(event);
+            }
         }
     }
 }

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/DisconnectRequestHandler.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/DisconnectRequestHandler.java
@@ -11,6 +11,8 @@
 
 package com.microsoft.java.debug.core.adapter.handler;
 
+import java.util.logging.Logger;
+
 import com.microsoft.java.debug.core.IDebugSession;
 import com.microsoft.java.debug.core.adapter.IDebugAdapterContext;
 import com.microsoft.java.debug.core.protocol.Messages.Response;
@@ -18,7 +20,12 @@ import com.microsoft.java.debug.core.protocol.Requests.Arguments;
 import com.microsoft.java.debug.core.protocol.Requests.Command;
 import com.microsoft.java.debug.core.protocol.Requests.DisconnectArguments;
 
+
 public class DisconnectRequestHandler extends AbstractDisconnectRequestHandler {
+
+    public DisconnectRequestHandler(Logger logger) {
+        super(logger);
+    }
 
     @Override
     public void destroyDebugSession(Command command, Arguments arguments, Response response, IDebugAdapterContext context) {

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/DisconnectRequestWithoutDebuggingHandler.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/DisconnectRequestWithoutDebuggingHandler.java
@@ -11,13 +11,20 @@
 
 package com.microsoft.java.debug.core.adapter.handler;
 
+import java.util.logging.Logger;
+
 import com.microsoft.java.debug.core.adapter.IDebugAdapterContext;
 import com.microsoft.java.debug.core.protocol.Messages.Response;
 import com.microsoft.java.debug.core.protocol.Requests.Arguments;
 import com.microsoft.java.debug.core.protocol.Requests.Command;
 import com.microsoft.java.debug.core.protocol.Requests.DisconnectArguments;
 
+
 public class DisconnectRequestWithoutDebuggingHandler extends AbstractDisconnectRequestHandler {
+
+    public DisconnectRequestWithoutDebuggingHandler(Logger logger) {
+        super(logger);
+    }
 
     @Override
     public void destroyDebugSession(Command command, Arguments arguments, Response response, IDebugAdapterContext context) {

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/EvaluateRequestHandler.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/EvaluateRequestHandler.java
@@ -23,7 +23,6 @@ import java.util.logging.Logger;
 
 import org.apache.commons.lang3.StringUtils;
 
-import com.microsoft.java.debug.core.Configuration;
 import com.microsoft.java.debug.core.DebugException;
 import com.microsoft.java.debug.core.DebugSettings;
 import com.microsoft.java.debug.core.adapter.AdapterUtils;
@@ -49,7 +48,11 @@ import com.sun.jdi.Value;
 import com.sun.jdi.VoidValue;
 
 public class EvaluateRequestHandler implements IDebugRequestHandler {
-    protected final Logger logger = Logger.getLogger(Configuration.LOGGER_NAME);
+    protected final Logger logger;
+
+    public EvaluateRequestHandler(Logger logger) {
+        this.logger = logger;
+    }
 
     @Override
     public List<Command> getTargetCommands() {

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/EvaluateRequestHandler.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/EvaluateRequestHandler.java
@@ -49,7 +49,7 @@ import com.sun.jdi.Value;
 import com.sun.jdi.VoidValue;
 
 public class EvaluateRequestHandler implements IDebugRequestHandler {
-    protected static final Logger logger = Logger.getLogger(Configuration.LOGGER_NAME);
+    protected final Logger logger = Logger.getLogger(Configuration.LOGGER_NAME);
 
     @Override
     public List<Command> getTargetCommands() {

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/ExceptionInfoRequestHandler.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/ExceptionInfoRequestHandler.java
@@ -19,7 +19,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import com.microsoft.java.debug.core.Configuration;
 import com.microsoft.java.debug.core.DebugUtility;
 import com.microsoft.java.debug.core.JdiExceptionReference;
 import com.microsoft.java.debug.core.adapter.AdapterUtils;
@@ -42,7 +41,11 @@ import com.sun.jdi.ThreadReference;
 import com.sun.jdi.Value;
 
 public class ExceptionInfoRequestHandler implements IDebugRequestHandler {
-    protected final Logger logger = Logger.getLogger(Configuration.LOGGER_NAME);
+    protected final Logger logger;
+
+    public ExceptionInfoRequestHandler(Logger logger) {
+        this.logger = logger;
+    }
 
     @Override
     public List<Command> getTargetCommands() {

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/ExceptionInfoRequestHandler.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/ExceptionInfoRequestHandler.java
@@ -42,7 +42,7 @@ import com.sun.jdi.ThreadReference;
 import com.sun.jdi.Value;
 
 public class ExceptionInfoRequestHandler implements IDebugRequestHandler {
-    protected static final Logger logger = Logger.getLogger(Configuration.LOGGER_NAME);
+    protected final Logger logger = Logger.getLogger(Configuration.LOGGER_NAME);
 
     @Override
     public List<Command> getTargetCommands() {

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/LaunchRequestHandler.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/LaunchRequestHandler.java
@@ -20,10 +20,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -62,7 +59,7 @@ import com.sun.jdi.connect.VMStartException;
 import com.sun.jdi.event.VMDisconnectEvent;
 
 public class LaunchRequestHandler implements IDebugRequestHandler {
-    protected static final Logger logger = Logger.getLogger(Configuration.LOGGER_NAME);
+    protected final Logger logger = Logger.getLogger(Configuration.LOGGER_NAME);
     protected static final long RUNINTERMINAL_TIMEOUT = 10 * 1000;
     protected ILaunchDelegate activeLaunchHandler;
     private CompletableFuture<Boolean> waitForDebuggeeConsole = new CompletableFuture<>();
@@ -276,32 +273,6 @@ public class LaunchRequestHandler implements IDebugRequestHandler {
         }
 
         return new OutputEvent(category, message);
-    }
-
-    protected static String[] constructEnvironmentVariables(LaunchArguments launchArguments) {
-        String[] envVars = null;
-        if (launchArguments.env != null && !launchArguments.env.isEmpty()) {
-            Map<String, String> environment = new HashMap<>(System.getenv());
-            List<String> duplicated = new ArrayList<>();
-            for (Entry<String, String> entry : launchArguments.env.entrySet()) {
-                if (environment.containsKey(entry.getKey())) {
-                    duplicated.add(entry.getKey());
-                }
-                environment.put(entry.getKey(), entry.getValue());
-            }
-            // For duplicated variables, show a warning message.
-            if (!duplicated.isEmpty()) {
-                logger.warning(String.format("There are duplicated environment variables. The values specified in launch.json will be used. "
-                        + "Here are the duplicated entries: %s.", String.join(",", duplicated)));
-            }
-
-            envVars = new String[environment.size()];
-            int i = 0;
-            for (Entry<String, String> entry : environment.entrySet()) {
-                envVars[i++] = entry.getKey() + "=" + entry.getValue();
-            }
-        }
-        return envVars;
     }
 
     public static String parseMainClassWithoutModuleName(String mainClass) {

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/LaunchWithDebuggingDelegate.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/LaunchWithDebuggingDelegate.java
@@ -56,6 +56,10 @@ public class LaunchWithDebuggingDelegate extends AbstractLaunchDelegate {
     private static final String TERMINAL_TITLE = "Java Debug Console";
     protected static final long RUNINTERMINAL_TIMEOUT = 10 * 1000;
 
+    public LaunchWithDebuggingDelegate(Logger logger) {
+        super(logger);
+    }
+
     @Override
     public CompletableFuture<Response> launchInTerminal(LaunchArguments launchArguments, Response response, IDebugAdapterContext context) {
         CompletableFuture<Response> resultFuture = new CompletableFuture<>();
@@ -98,7 +102,7 @@ public class LaunchWithDebuggingDelegate extends AbstractLaunchDelegate {
                         if (runResponse.success) {
                             try {
                                 VirtualMachine vm = listenConnector.accept(args);
-                                context.setDebugSession(new DebugSession(vm));
+                                context.setDebugSession(new DebugSession(vm, logger));
                                 logger.info("Launching debuggee in terminal console succeeded.");
                                 resultFuture.complete(response);
                             } catch (TransportTimeoutException e) {
@@ -178,7 +182,8 @@ public class LaunchWithDebuggingDelegate extends AbstractLaunchDelegate {
                 Arrays.asList(launchArguments.modulePaths),
                 Arrays.asList(launchArguments.classPaths),
                 launchArguments.cwd,
-                constructEnvironmentVariables(launchArguments));
+                constructEnvironmentVariables(launchArguments),
+                logger);
         context.setDebugSession(debugSession);
 
         logger.info("Launching debuggee VM succeeded.");

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/LaunchWithDebuggingDelegate.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/LaunchWithDebuggingDelegate.java
@@ -24,7 +24,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.SystemUtils;
 
 import com.google.gson.JsonObject;
-import com.microsoft.java.debug.core.Configuration;
 import com.microsoft.java.debug.core.DebugException;
 import com.microsoft.java.debug.core.DebugSession;
 import com.microsoft.java.debug.core.DebugUtility;
@@ -52,9 +51,7 @@ import com.sun.jdi.connect.ListeningConnector;
 import com.sun.jdi.connect.TransportTimeoutException;
 import com.sun.jdi.connect.VMStartException;
 
-public class LaunchWithDebuggingDelegate implements ILaunchDelegate {
-
-    protected static final Logger logger = Logger.getLogger(Configuration.LOGGER_NAME);
+public class LaunchWithDebuggingDelegate extends AbstractLaunchDelegate {
     private static final int ATTACH_TERMINAL_TIMEOUT = 20 * 1000;
     private static final String TERMINAL_TITLE = "Java Debug Console";
     protected static final long RUNINTERMINAL_TIMEOUT = 10 * 1000;
@@ -181,7 +178,7 @@ public class LaunchWithDebuggingDelegate implements ILaunchDelegate {
                 Arrays.asList(launchArguments.modulePaths),
                 Arrays.asList(launchArguments.classPaths),
                 launchArguments.cwd,
-                LaunchRequestHandler.constructEnvironmentVariables(launchArguments));
+                constructEnvironmentVariables(launchArguments));
         context.setDebugSession(debugSession);
 
         logger.info("Launching debuggee VM succeeded.");

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/LaunchWithoutDebuggingDelegate.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/LaunchWithoutDebuggingDelegate.java
@@ -18,10 +18,8 @@ import java.nio.file.Paths;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.function.Consumer;
-import java.util.logging.Logger;
 
 import com.google.gson.JsonObject;
-import com.microsoft.java.debug.core.Configuration;
 import com.microsoft.java.debug.core.DebugException;
 import com.microsoft.java.debug.core.adapter.ErrorCode;
 import com.microsoft.java.debug.core.adapter.IDebugAdapterContext;
@@ -36,8 +34,7 @@ import com.microsoft.java.debug.core.protocol.Requests.RunInTerminalRequestArgum
 import com.sun.jdi.connect.IllegalConnectorArgumentsException;
 import com.sun.jdi.connect.VMStartException;
 
-public class LaunchWithoutDebuggingDelegate implements ILaunchDelegate {
-    protected static final Logger logger = Logger.getLogger(Configuration.LOGGER_NAME);
+public class LaunchWithoutDebuggingDelegate extends AbstractLaunchDelegate {
     protected static final String TERMINAL_TITLE = "Java Process Console";
     protected static final long RUNINTERMINAL_TIMEOUT = 10 * 1000;
     private Consumer<IDebugAdapterContext> terminateHandler;
@@ -54,7 +51,7 @@ public class LaunchWithoutDebuggingDelegate implements ILaunchDelegate {
         if (launchArguments.cwd != null && Files.isDirectory(Paths.get(launchArguments.cwd))) {
             workingDir = new File(launchArguments.cwd);
         }
-        Process debuggeeProcess = Runtime.getRuntime().exec(cmds, LaunchRequestHandler.constructEnvironmentVariables(launchArguments),
+        Process debuggeeProcess = Runtime.getRuntime().exec(cmds, constructEnvironmentVariables(launchArguments),
                 workingDir);
         new Thread() {
             public void run() {

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/LaunchWithoutDebuggingDelegate.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/LaunchWithoutDebuggingDelegate.java
@@ -18,6 +18,7 @@ import java.nio.file.Paths;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.function.Consumer;
+import java.util.logging.Logger;
 
 import com.google.gson.JsonObject;
 import com.microsoft.java.debug.core.DebugException;
@@ -39,7 +40,8 @@ public class LaunchWithoutDebuggingDelegate extends AbstractLaunchDelegate {
     protected static final long RUNINTERMINAL_TIMEOUT = 10 * 1000;
     private Consumer<IDebugAdapterContext> terminateHandler;
 
-    public LaunchWithoutDebuggingDelegate(Consumer<IDebugAdapterContext> terminateHandler) {
+    public LaunchWithoutDebuggingDelegate(Consumer<IDebugAdapterContext> terminateHandler, Logger logger) {
+        super(logger);
         this.terminateHandler = terminateHandler;
     }
 

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/SetBreakpointsRequestHandler.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/SetBreakpointsRequestHandler.java
@@ -54,7 +54,7 @@ import com.sun.jdi.event.StepEvent;
 
 public class SetBreakpointsRequestHandler implements IDebugRequestHandler {
 
-    private static final Logger logger = Logger.getLogger(Configuration.LOGGER_NAME);
+    private final Logger logger = Logger.getLogger(Configuration.LOGGER_NAME);
 
     private BreakpointManager manager = new BreakpointManager();
 

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/SetBreakpointsRequestHandler.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/SetBreakpointsRequestHandler.java
@@ -21,7 +21,6 @@ import java.util.logging.Logger;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.StringUtils;
 
-import com.microsoft.java.debug.core.Configuration;
 import com.microsoft.java.debug.core.DebugException;
 import com.microsoft.java.debug.core.IBreakpoint;
 import com.microsoft.java.debug.core.IDebugSession;
@@ -53,12 +52,15 @@ import com.sun.jdi.event.Event;
 import com.sun.jdi.event.StepEvent;
 
 public class SetBreakpointsRequestHandler implements IDebugRequestHandler {
-
-    private final Logger logger = Logger.getLogger(Configuration.LOGGER_NAME);
-
-    private BreakpointManager manager = new BreakpointManager();
+    private final Logger logger;
+    private final BreakpointManager manager;
 
     private boolean registered = false;
+
+    public SetBreakpointsRequestHandler(Logger logger) {
+        this.logger = logger;
+        this.manager = new BreakpointManager(logger);
+    }
 
     @Override
     public List<Command> getTargetCommands() {

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/VariablesRequestHandler.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/VariablesRequestHandler.java
@@ -26,7 +26,6 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
-import com.microsoft.java.debug.core.Configuration;
 import com.microsoft.java.debug.core.DebugSettings;
 import com.microsoft.java.debug.core.adapter.AdapterUtils;
 import com.microsoft.java.debug.core.adapter.ErrorCode;
@@ -61,7 +60,11 @@ import com.sun.jdi.Type;
 import com.sun.jdi.Value;
 
 public class VariablesRequestHandler implements IDebugRequestHandler {
-    protected final Logger logger = Logger.getLogger(Configuration.LOGGER_NAME);
+    protected final Logger logger;
+
+    public VariablesRequestHandler(Logger logger) {
+        this.logger = logger;
+    }
 
     @Override
     public List<Command> getTargetCommands() {

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/VariablesRequestHandler.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/VariablesRequestHandler.java
@@ -61,7 +61,7 @@ import com.sun.jdi.Type;
 import com.sun.jdi.Value;
 
 public class VariablesRequestHandler implements IDebugRequestHandler {
-    protected static final Logger logger = Logger.getLogger(Configuration.LOGGER_NAME);
+    protected final Logger logger = Logger.getLogger(Configuration.LOGGER_NAME);
 
     @Override
     public List<Command> getTargetCommands() {

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/variables/VariableUtils.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/variables/VariableUtils.java
@@ -11,6 +11,8 @@
 
 package com.microsoft.java.debug.core.adapter.variables;
 
+import static java.lang.String.CASE_INSENSITIVE_ORDER;
+
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
@@ -82,7 +84,7 @@ public abstract class VariableUtils {
         List<Field> fields = obj.referenceType().allFields().stream().filter(t -> includeStatic || !t.isStatic())
                 .sorted(Comparator.comparing(Field::isStatic)
                         .reversed()
-                        .thenComparing(Field::name))
+                        .thenComparing(Field::name, CASE_INSENSITIVE_ORDER))
                 .collect(Collectors.toList());
 
         fields.forEach(f -> {

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/protocol/AbstractProtocolServer.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/protocol/AbstractProtocolServer.java
@@ -33,7 +33,6 @@ import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import com.microsoft.java.debug.core.Configuration;
 import com.microsoft.java.debug.core.protocol.Events.DebugEvent;
 
 import io.reactivex.disposables.Disposable;
@@ -41,7 +40,7 @@ import io.reactivex.schedulers.Schedulers;
 import io.reactivex.subjects.PublishSubject;
 
 public abstract class AbstractProtocolServer implements IProtocolServer {
-    private final Logger logger = Logger.getLogger(Configuration.LOGGER_NAME);
+    protected final Logger logger;
     private static final int BUFFER_SIZE = 4096;
     private static final String TWO_CRLF = "\r\n\r\n";
     private static final Pattern CONTENT_LENGTH_MATCHER = Pattern.compile("Content-Length: (\\d+)");
@@ -68,7 +67,8 @@ public abstract class AbstractProtocolServer implements IProtocolServer {
      * @param output
      *            the output stream
      */
-    public AbstractProtocolServer(InputStream input, OutputStream output) {
+    public AbstractProtocolServer(InputStream input, OutputStream output, Logger logger) {
+        this.logger = logger;
         this.reader = new BufferedReader(new InputStreamReader(input, PROTOCOL_ENCODING));
         this.writer = new PrintWriter(new BufferedWriter(new OutputStreamWriter(output, PROTOCOL_ENCODING)));
         this.contentLength = -1;

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/protocol/AbstractProtocolServer.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/protocol/AbstractProtocolServer.java
@@ -33,6 +33,7 @@ import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import com.microsoft.java.debug.core.Configuration;
 import com.microsoft.java.debug.core.protocol.Events.DebugEvent;
 
 import io.reactivex.disposables.Disposable;
@@ -40,7 +41,7 @@ import io.reactivex.schedulers.Schedulers;
 import io.reactivex.subjects.PublishSubject;
 
 public abstract class AbstractProtocolServer implements IProtocolServer {
-    private static final Logger logger = Logger.getLogger("java-debug");
+    private final Logger logger = Logger.getLogger(Configuration.LOGGER_NAME);
     private static final int BUFFER_SIZE = 4096;
     private static final String TWO_CRLF = "\r\n\r\n";
     private static final Pattern CONTENT_LENGTH_MATCHER = Pattern.compile("Content-Length: (\\d+)");

--- a/com.microsoft.java.debug.core/src/test/java/com/microsoft/java/debug/core/DebugSessionFactory.java
+++ b/com.microsoft.java.debug.core/src/test/java/com/microsoft/java/debug/core/DebugSessionFactory.java
@@ -19,6 +19,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.logging.Logger;
 
 import org.apache.commons.io.FileUtils;
 
@@ -27,6 +28,7 @@ import com.sun.jdi.VMDisconnectedException;
 import com.sun.jdi.event.VMDisconnectEvent;
 
 public class DebugSessionFactory {
+    private static final Logger logger = Logger.getLogger(Configuration.LOGGER_NAME);
     private static final String TEST_ROOT = "../com.microsoft.java.debug.test/project";
     private static String rootPath = new File(TEST_ROOT).getAbsolutePath();
     private static Set<String> readyForLaunchProjects = new HashSet<>();
@@ -52,7 +54,7 @@ public class DebugSessionFactory {
             String projectRoot = new File(rootPath, name).getAbsolutePath();
             try {
                 final IDebugSession debugSession = DebugUtility.launch(Bootstrap.virtualMachineManager(), mainClass, "", "",
-                        null, new File(projectRoot, "bin").getAbsolutePath(), null, null);
+                        null, new File(projectRoot, "bin").getAbsolutePath(), null, null, logger);
                 debugSession.getEventHub().events().subscribe(debugEvent -> {
                     if (debugEvent.event instanceof VMDisconnectEvent) {
                         try {


### PR DESCRIPTION
Currently all of the loggers are static. This makes them non-static and allows the users to customize them on creation.