### PR TITLE
Open VariableUtils API

### DIFF
--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/VariablesRequestHandler.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/VariablesRequestHandler.java
@@ -33,6 +33,7 @@ import com.microsoft.java.debug.core.adapter.IDebugRequestHandler;
 import com.microsoft.java.debug.core.adapter.IEvaluationProvider;
 import com.microsoft.java.debug.core.adapter.IStackFrameManager;
 import com.microsoft.java.debug.core.adapter.variables.IVariableFormatter;
+import com.microsoft.java.debug.core.adapter.variables.IVariableProvider;
 import com.microsoft.java.debug.core.adapter.variables.JavaLogicalStructure;
 import com.microsoft.java.debug.core.adapter.variables.JavaLogicalStructure.LogicalStructureExpression;
 import com.microsoft.java.debug.core.adapter.variables.JavaLogicalStructure.LogicalVariable;
@@ -78,6 +79,7 @@ public class VariablesRequestHandler implements IDebugRequestHandler {
         boolean showStaticVariables = DebugSettings.getCurrent().showStaticVariables;
 
         Map<String, Object> options = variableFormatter.getDefaultOptions();
+        IVariableProvider evaluateNameUtils = context.getProvider(IVariableProvider.class);
         VariableUtils.applyFormatterOptions(options, varArgs.format != null && varArgs.format.hex);
         IEvaluationProvider evaluationEngine = context.getProvider(IEvaluationProvider.class);
 
@@ -260,12 +262,12 @@ public class VariablesRequestHandler implements IDebugRequestHandler {
                 String typeName = ((ObjectReference) containerNode.getProxiedVariable()).referenceType().name();
                 // TODO: This replacement will possibly change the $ in the class name itself.
                 typeName = typeName.replaceAll("\\$", ".");
-                evaluateName = VariableUtils.getEvaluateName(javaVariable.evaluateName, "((" + typeName + ")" + containerEvaluateName + ")", false);
+                evaluateName = evaluateNameUtils.getEvaluateName(javaVariable.evaluateName, "((" + typeName + ")" + containerEvaluateName + ")", false);
             } else {
                 if (containerEvaluateName != null && containerEvaluateName.contains("%s")) {
                     evaluateName = String.format(containerEvaluateName, javaVariable.evaluateName);
                 } else {
-                    evaluateName = VariableUtils.getEvaluateName(javaVariable.evaluateName, containerEvaluateName, containerNode.isIndexedVariable());
+                    evaluateName = evaluateNameUtils.getEvaluateName(javaVariable.evaluateName, containerEvaluateName, containerNode.isIndexedVariable());
                 }
             }
 

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/VariablesRequestHandler.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/VariablesRequestHandler.java
@@ -79,7 +79,7 @@ public class VariablesRequestHandler implements IDebugRequestHandler {
         boolean showStaticVariables = DebugSettings.getCurrent().showStaticVariables;
 
         Map<String, Object> options = variableFormatter.getDefaultOptions();
-        IVariableProvider evaluateNameUtils = context.getProvider(IVariableProvider.class);
+        IVariableProvider variableProvider = context.getProvider(IVariableProvider.class);
         VariableUtils.applyFormatterOptions(options, varArgs.format != null && varArgs.format.hex);
         IEvaluationProvider evaluationEngine = context.getProvider(IEvaluationProvider.class);
 
@@ -262,12 +262,12 @@ public class VariablesRequestHandler implements IDebugRequestHandler {
                 String typeName = ((ObjectReference) containerNode.getProxiedVariable()).referenceType().name();
                 // TODO: This replacement will possibly change the $ in the class name itself.
                 typeName = typeName.replaceAll("\\$", ".");
-                evaluateName = evaluateNameUtils.getEvaluateName(javaVariable.evaluateName, "((" + typeName + ")" + containerEvaluateName + ")", false);
+                evaluateName = variableProvider.getEvaluateName(javaVariable.evaluateName, "((" + typeName + ")" + containerEvaluateName + ")", false);
             } else {
                 if (containerEvaluateName != null && containerEvaluateName.contains("%s")) {
                     evaluateName = String.format(containerEvaluateName, javaVariable.evaluateName);
                 } else {
-                    evaluateName = evaluateNameUtils.getEvaluateName(javaVariable.evaluateName, containerEvaluateName, containerNode.isIndexedVariable());
+                    evaluateName = variableProvider.getEvaluateName(javaVariable.evaluateName, containerEvaluateName, containerNode.isIndexedVariable());
                 }
             }
 

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/variables/IVariableProvider.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/variables/IVariableProvider.java
@@ -1,0 +1,14 @@
+package com.microsoft.java.debug.core.adapter.variables;
+
+import com.microsoft.java.debug.core.adapter.IProvider;
+
+public interface IVariableProvider extends IProvider {
+  /**
+   * Get the name for evaluation of variable.
+   *
+   * @param name           the variable name, if any
+   * @param containerName  the container name, if any
+   * @param isArrayElement is the variable an array element?
+   */
+  public String getEvaluateName(String name, String containerName, boolean isArrayElement);
+}

--- a/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/variables/VariableProvider.java
+++ b/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/variables/VariableProvider.java
@@ -1,0 +1,8 @@
+package com.microsoft.java.debug.core.adapter.variables;
+
+public class VariableProvider implements IVariableProvider {
+    @Override
+    public String getEvaluateName(String name, String containerName, boolean isArrayElement) {
+        return VariableUtils.getEvaluateName(name, containerName, isArrayElement);
+    }
+}

--- a/com.microsoft.java.debug.plugin/src/main/java/com/microsoft/java/debug/plugin/internal/JdtProviderContextFactory.java
+++ b/com.microsoft.java.debug.plugin/src/main/java/com/microsoft/java/debug/plugin/internal/JdtProviderContextFactory.java
@@ -38,6 +38,7 @@ public abstract class JdtProviderContextFactory {
         context.registerProvider(IEvaluationProvider.class, new JdtEvaluationProvider());
         context.registerProvider(ICompletionsProvider.class, new CompletionsProvider());
         context.registerProvider(IStepFilterProvider.class, new StepFilterProvider());
+        context.registerProvider(IVariableProvider.class, new VariableProvider());
 
         return context;
     }


### PR DESCRIPTION
In [this pr](https://github.com/scalacenter/scala-debug-adapter/pull/456), we needed to be able to modify the expression of an array element when adding it to watches. It was not possible with the current implementation so I opened it by transforming `VariableUtils` (that contains the parsing method) into a provider to use my own implementation for Scala